### PR TITLE
fix(frontend) docker not spinning if npm install done on another arch

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,8 +4,10 @@ WORKDIR /home/docker/app
 
 RUN rm -rf .angular/cache
 
-RUN useradd -r -g users docker
-USER docker
+# npm install inside the docker
+ADD package.json /tmp/package.json
+RUN cd /tmp && npm install
+RUN mkdir -p /opt/app && cp -a /tmp/node_modules /opt/app/
 
 CMD ["npm", "start"]
 


### PR DESCRIPTION
Adding these lines does the install of packages with npm. The user lines were removed due to a bug where npm couldn't write files to the folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application environment setup process for improved dependency installation.
	- Streamlined the handling of npm packages and their location within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->